### PR TITLE
fix: include the missing header file

### DIFF
--- a/catmullclark/viewer.cpp
+++ b/catmullclark/viewer.cpp
@@ -15,6 +15,7 @@
 #include <map>
 #include <algorithm>
 #include <cmath>
+#include <ctime>
 
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"


### PR DESCRIPTION
## The Issue
It occurs the following compilation error.

```
LongestEdgeBisection2D/catmullclark/viewer.cpp:2333:23: error: ‘CLOCK_MONOTONIC’ was not declared in this scope
 2333 |         clock_gettime(CLOCK_MONOTONIC, &thisTime);
      |                       ^~~~~~~~~~~~~~~

LongestEdgeBisection2D/catmullclark/viewer.cpp:2333:9: error: ‘clock_gettime’ was not declared in this scope
 2333 |         clock_gettime(CLOCK_MONOTONIC, &thisTime);
      |         ^~~~~~~~~~~~~
```

## Development Environment
```
$ uname -r
5.19.1-3-MANJARO
```

```
$ clang++ -v
clang version 14.0.6
```

## Reproduce the compilation error
Follow the steps as below and you will see the error messages.
```
$ git clone git@github.com:jdupuy/LongestEdgeBisection2D.git
$ cd LongestEdgeBisection2D
$ git submodule update --init --recursive
$ mkdir build; cd build; cmake ..; make
```

## How to fix it
Just include one file which is `<ctime>`. My PR has done for you. 